### PR TITLE
Update to Thymeleaf Spring Security 5 Extras

### DIFF
--- a/citely-web/pom.xml
+++ b/citely-web/pom.xml
@@ -21,8 +21,8 @@
         <spring-security-jwt.version>1.0.10.RELEASE</spring-security-jwt.version>
         <bootstrap.version>3.3.7</bootstrap.version>
         <jquery.version>3.2.1</jquery.version>
-        <thymeleaf.version>3.0.10.RELEASE</thymeleaf.version>
-        <thymeleaf-extras.version>3.0.3.RELEASE</thymeleaf-extras.version>
+        <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
+        <thymeleaf-extras.version>3.0.4.RELEASE</thymeleaf-extras.version>
     </properties>
 
     <dependencies>
@@ -144,14 +144,14 @@
 
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
-            <artifactId>thymeleaf-extras-springsecurity4</artifactId>
+            <artifactId>thymeleaf-extras-springsecurity5</artifactId>
             <version>${thymeleaf-extras.version}</version>
         </dependency>
 
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.1</version>
         </dependency>
 
         <dependency>

--- a/citely-web/src/main/java/org/blueclawsoft/citely/config/ThymeleafConfig.java
+++ b/citely-web/src/main/java/org/blueclawsoft/citely/config/ThymeleafConfig.java
@@ -40,7 +40,7 @@ public class ThymeleafConfig implements ApplicationContextAware {
     public SpringTemplateEngine getTemplateEngine() {
         Set<IDialect> dialects = new HashSet<IDialect>();
         dialects.add(new nz.net.ultraq.thymeleaf.LayoutDialect());
-        dialects.add(new org.thymeleaf.extras.springsecurity4.dialect.SpringSecurityDialect());
+        dialects.add(new org.thymeleaf.extras.springsecurity5.dialect.SpringSecurityDialect());
 
         SpringTemplateEngine engine = new SpringTemplateEngine();
         engine.setTemplateResolver(getTemplateResolver());


### PR DESCRIPTION
Increment dependency versions to use Spring 5 versions of Thymeleaf
extras.  Mostly these are things that are used for security annotations
in templates.